### PR TITLE
ci: dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Enable version updates for gradle dependencies
+  - package-ecosystem: "gradle"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+      time: "11:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "11:00"
+      timezone: "Europe/Berlin"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,26 @@
+
+name: Dependency Submission
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v4
+        with:
+          artifact-retention-days: 1 # see https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#reducing-storage-costs-for-saved-dependency-graph-artifacts

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
-    id("cn.lalaki.central") version "1.2.5"
+    alias(libs.plugins.lalaki.central.plugin)
 }
 
 group = "io.github.goatfryed"
@@ -37,16 +37,15 @@ javadoc {
 }
 
 dependencies {
-    implementation 'org.apache.commons:commons-lang3:3.16.0'
-    implementation 'commons-io:commons-io:2.16.1'
-    implementation 'org.jetbrains:annotations:23.0.0'
+    implementation libs.apache.commons.lang
+    implementation libs.commons.io
+    implementation libs.jetbrains.annotations
 
-    implementation 'org.junit.jupiter:junit-jupiter:5.11.0'
-    implementation 'org.jetbrains:annotations:23.0.0'
-    api 'org.assertj:assertj-core:3.26.3'
+    implementation libs.junit
+    api libs.assertj
 
-    jsonApi 'net.javacrumbs.json-unit:json-unit-assertj:3.4.1'
-    xmlApi 'org.xmlunit:xmlunit-assertj:2.10.0'
+    jsonApi libs.javacrumbs.json.unit
+    xmlApi libs.xml.unit
 }
 
 testing {
@@ -56,7 +55,7 @@ testing {
         test {
             useJUnitJupiter()
             dependencies {
-                implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+                implementation libs.jackson
             }
         }
 
@@ -83,10 +82,10 @@ testing {
         withType(JvmTestSuite).matching { it.name in ["testSpi","testRecipes"] }.configureEach {
             dependencies {
                 implementation project()
-                implementation 'org.apache.commons:commons-lang3:3.16.0'
-                implementation 'commons-io:commons-io:2.16.1'
-                implementation 'org.jetbrains:annotations:23.0.0'
-                implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+                implementation libs.apache.commons.lang
+                implementation libs.commons.io
+                implementation libs.jetbrains.annotations
+                implementation libs.jackson
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,23 @@
+[versions]
+apache-commons-lang = "3.16.0"
+assertj = "3.26.3"
+commons-io = "2.16.1"
+jackson = "2.17.2"
+javacrumbs-json-unit = "3.4.1"
+jetbrains-annotations = "23.0.0"
+junit = "5.11.0"
+lalaki-central-plugin = "1.2.5"
+xml-unit = "2.10.0"
+
+[plugins]
+lalaki-central-plugin = { id = "cn.lalaki.central", version.ref = "lalaki-central-plugin" }
+
+[libraries]
+apache-commons-lang = { module = "org.apache.commons:commons-lang3", version.ref = "apache-commons-lang"}
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
+jackson = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+javacrumbs-json-unit = { module = "net.javacrumbs.json-unit:json-unit-assertj", version.ref = "javacrumbs-json-unit" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
+junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+xml-unit = { module = "org.xmlunit:xmlunit-assertj", version.ref = "xml-unit" }


### PR DESCRIPTION
This PR configures dependabot for the repository.

It adds a github workflow to submit dependencies to dependabot and adds a dependabot configuration for automatic version update.

On this occasion the dependency management is migrated to [gradle version catalog](https://docs.gradle.org/current/userguide/version_catalogs.html)


Please make sure to activate dependabot under Settings → Code Security:

- Enable Dependabot Alerts
- Enable Dependabot Security Updates
- Enable Dependabot on Actions runners

The Dependabot version updates will be activated automatically with the configuration provided by this PR